### PR TITLE
Update to Kotlin 1.6 and add arm64 ios and watchos simulator targets

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
-version=0.14.0-SNAPSHOT
+version=0.17.0-SNAPSHOT
 group=com.soywiz.korlibs
 
 # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
-kotlinVersion=1.5.20
+kotlinVersion=1.6.0
 # https://mvnrepository.com/artifact/junit/junit
 junitVersion=4.13.2
 # https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
-androidToolsBuildGradleVersion=4.2.1
+androidToolsBuildGradleVersion=4.2.2
 # https://plugins.gradle.org/plugin/com.gradle.plugin-publish
-gradlePublishPluginVersion=0.15.0
+gradlePublishPluginVersion=0.18.0
 
 project.bintray.org=korlibs
 project.bintray.repository=korlibs

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/soywiz/korlibs/KorlibsKotlinVersion.kt
+++ b/src/main/kotlin/com/soywiz/korlibs/KorlibsKotlinVersion.kt
@@ -1,3 +1,3 @@
 package com.soywiz.korlibs
 
-val KORLIBS_KOTLIN_VERSION = "1.5.20"
+val KORLIBS_KOTLIN_VERSION = "1.6.0"

--- a/src/main/kotlin/com/soywiz/korlibs/KorlibsPlugin.kt
+++ b/src/main/kotlin/com/soywiz/korlibs/KorlibsPlugin.kt
@@ -151,12 +151,12 @@ class KorlibsExtension(val project: Project, val nativeEnabled: Boolean, val and
 			}
 		}
 	}
-    val MACOS_DESKTOP_NATIVE_TARGETS = setOf("macosX64")
+    val MACOS_DESKTOP_NATIVE_TARGETS = setOf("macosX64", "macosArm64")
     //val WINDOWS_DESKTOP_NATIVE_TARGETS = listOf("mingwX64", "mingwX86")
     val WINDOWS_DESKTOP_NATIVE_TARGETS = setOf("mingwX64")
     val DESKTOP_NATIVE_TARGETS = LINUX_DESKTOP_NATIVE_TARGETS + MACOS_DESKTOP_NATIVE_TARGETS + WINDOWS_DESKTOP_NATIVE_TARGETS
-    val IOS_TARGETS = setOf("iosArm64", "iosArm32", "iosX64")
-	val WATCHOS_TARGETS = if (watchosEnabled) setOf("watchosArm64", "watchosArm32", "watchosX86") else setOf()
+    val IOS_TARGETS = setOf("iosArm64", "iosArm32", "iosX64", "iosSimulatorArm64")
+	val WATCHOS_TARGETS = if (watchosEnabled) setOf("watchosArm64", "watchosArm32", "watchosX86", "watchosSimulatorArm64") else setOf()
 	val TVOS_TARGETS = if (tvosEnabled) setOf("tvosArm64", "tvosX64") else setOf()
 	val IOS_WATCHOS_TVOS_TARGETS = IOS_TARGETS + WATCHOS_TARGETS + TVOS_TARGETS
 	val IOS_TVOS_TARGETS = IOS_TARGETS + TVOS_TARGETS

--- a/src/main/kotlin/com/soywiz/korlibs/targets/Native.kt
+++ b/src/main/kotlin/com/soywiz/korlibs/targets/Native.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.*
 val linuxEnabled by lazy {
 	!Os.isFamily(Os.FAMILY_MAC) && !Os.isFamily(Os.FAMILY_WINDOWS)
 }
-val isArm get() = listOf("arm", "arm64", "aarch64").any { org.apache.tools.ant.taskdefs.condition.Os.isArch(it) }
+val isArm get() = listOf("arm", "arm64", "aarch64").any { Os.isArch(it) }
 
 fun Project.configureTargetNative() {
 	val nativeExtraJar = tasks.create<Jar>("nativeExtraJar") {
@@ -108,9 +108,9 @@ fun Project.configureTargetNative() {
 			when {
 				Os.isFamily(Os.FAMILY_WINDOWS) -> run { mingwX64("nativeCommon"); mingwX64("nativePosix") }
 				Os.isFamily(Os.FAMILY_MAC) -> if (isArm) run {
-                    macosArm64("nativeCommon"); macosArm64("nativePosix")
+					macosArm64("nativeCommon"); macosArm64("nativePosix")
 				} else run {
-                    macosX64("nativeCommon"); macosX64("nativePosix")
+					macosX64("nativeCommon"); macosX64("nativePosix")
 				}
 				else -> run {
 					if (linuxEnabled) {

--- a/src/main/kotlin/com/soywiz/korlibs/targets/Native.kt
+++ b/src/main/kotlin/com/soywiz/korlibs/targets/Native.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.*
 val linuxEnabled by lazy {
 	!Os.isFamily(Os.FAMILY_MAC) && !Os.isFamily(Os.FAMILY_WINDOWS)
 }
+val isArm get() = listOf("arm", "arm64", "aarch64").any { org.apache.tools.ant.taskdefs.condition.Os.isArch(it) }
 
 fun Project.configureTargetNative() {
 	val nativeExtraJar = tasks.create<Jar>("nativeExtraJar") {
@@ -38,6 +39,9 @@ fun Project.configureTargetNative() {
 		iosArm64() {
 			extraNative()
 		}
+		iosSimulatorArm64() {
+			extraNative()
+		}
 		/////////////////////////////////////////
 		if (korlibs.tvosEnabled) {
 			tvosX64() {
@@ -58,9 +62,15 @@ fun Project.configureTargetNative() {
 			watchosArm64() {
 				extraNative()
 			}
+			watchosSimulatorArm64() {
+				extraNative()
+			}
 		}
 		/////////////////////////////////////////
 		macosX64() {
+			extraNative()
+		}
+		macosArm64() {
 			extraNative()
 		}
 		if (linuxEnabled) {
@@ -97,7 +107,11 @@ fun Project.configureTargetNative() {
 		if (System.getProperty("idea.version") != null) {
 			when {
 				Os.isFamily(Os.FAMILY_WINDOWS) -> run { mingwX64("nativeCommon"); mingwX64("nativePosix") }
-				Os.isFamily(Os.FAMILY_MAC) -> run { macosX64("nativeCommon"); macosX64("nativePosix") }
+				Os.isFamily(Os.FAMILY_MAC) -> if (isArm) run {
+                    macosArm64("nativeCommon"); macosArm64("nativePosix")
+				} else run {
+                    macosX64("nativeCommon"); macosX64("nativePosix")
+				}
 				else -> run {
 					if (linuxEnabled) {
 						linuxX64("nativeCommon"); linuxX64("nativePosix")


### PR DESCRIPTION
Update Kotlin to 1.6.0, Gradle to 7.3, Gradle publish plugin to 0.18.0
Added missing targets for macOS, iOS and watchOS, specific for Apple Silicon introduced with Kotlin 1.5.30